### PR TITLE
Fix broken logo: use export default in webp declaration to match ES module import

### DIFF
--- a/src/types/images.d.ts
+++ b/src/types/images.d.ts
@@ -1,4 +1,4 @@
 declare module '*.webp' {
   const value: string;
-  export = value;
+  export default value;
 }


### PR DESCRIPTION
Fix broken logo: use export default in webp declaration to match ES module import