### PR TITLE
Minimizing empty space

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ ReactDOM.render(
   <React.StrictMode>
     <Provider value={overmindApp}>
       <main>
-        <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="p-px">
           <img
             className="mx-auto h-16 inline w-auto"
             src={logo}


### PR DESCRIPTION
Since the site is being rendered in an iframe (effectively) on WIX, we're minimizing any extra padding/whitespace around the outside of the app.